### PR TITLE
fix unmatched issue for php70 or higher

### DIFF
--- a/github-webhook-handler-php70.php
+++ b/github-webhook-handler-php70.php
@@ -1,0 +1,23 @@
+<?php
+
+// GitHub Webhook Secret.
+// Keep it the same with the 'Secret' field on your Webhooks / Manage webhook page of your respostory.
+$secret = "";
+
+// Path to your respostory on your server.
+// e.g. "/var/www/respostory"
+$path = "";
+
+// Headers deliveried from GitHub
+$signature = $_SERVER['HTTP_X_HUB_SIGNATURE'];
+
+if ($signature) {
+  $hash = "sha1=".hash_hmac('sha1', file_get_contents("php://input"), $secret);
+  if (strcmp($signature, $hash) == 0) {
+    echo shell_exec("cd {$path} && /usr/bin/git reset --hard origin/master && /usr/bin/git clean -f && /usr/bin/git pull 2>&1");
+    exit();
+  }
+}
+
+http_response_code(404);
+?>


### PR DESCRIPTION
Default setting makes $HTTP_RAW_POST_DATA abnormal, and it is suggested to use  `php://input`instead. 

See [more details](http://php.net/manual/en/reserved.variables.httprawpostdata.php)